### PR TITLE
Added feature to change preferences

### DIFF
--- a/lib/features/auth/presentation/screens/faq_screen.dart
+++ b/lib/features/auth/presentation/screens/faq_screen.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+class FAQScreen extends StatefulWidget {
+  const FAQScreen({super.key});
+
+  @override
+  State<FAQScreen> createState() => _FAQScreenState();
+}
+
+class _FAQScreenState extends State<FAQScreen> {
+  final TextEditingController _questionController = TextEditingController();
+
+  void _submit() {
+    final input = _questionController.text.trim();
+    if (input.isNotEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Submitted (placeholder)')),
+      );
+      _questionController.clear();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Help & FAQ')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Have a question or issue? Write it below:',
+              style: TextStyle(fontSize: 16),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _questionController,
+              maxLines: 4,
+              decoration: InputDecoration(
+                hintText: 'Type your question or feedback...',
+                border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: ElevatedButton.icon(
+                onPressed: _submit,
+                icon: const Icon(Icons.send),
+                label: const Text('Submit'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/screens/profile_screen.dart
+++ b/lib/features/auth/presentation/screens/profile_screen.dart
@@ -1,84 +1,178 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:mobile_app_project_bookstore/core/theme/theme_provider.dart';
 import 'package:mobile_app_project_bookstore/features/auth/presentation/providers/auth_providers.dart';
+import 'package:mobile_app_project_bookstore/features/user_profile/presentation/providers/user_profile_providers.dart';
+import 'faq_screen.dart';
 
-class ProfileScreen extends ConsumerWidget {
+class ProfileScreen extends ConsumerStatefulWidget {
   const ProfileScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ProfileScreen> createState() => _ProfileScreenState();
+}
+
+class _ProfileScreenState extends ConsumerState<ProfileScreen> {
+  final _formKey = GlobalKey<FormState>();
+  late TextEditingController _displayNameController;
+  final List<String> allGenres = [
+    'Fiction', 'Mystery', 'Romance', 'Sci-Fi', 'Fantasy',
+    'Biography', 'Self-Help', 'History', 'Thriller'
+  ];
+  List<String> selectedGenres = [];
+
+  @override
+  void initState() {
+    super.initState();
+    final user = FirebaseAuth.instance.currentUser;
+    _displayNameController = TextEditingController(text: user?.displayName ?? '');
+    if (user != null) {
+      _loadUserProfile(user.uid);
+    }
+  }
+
+  Future<void> _loadUserProfile(String uid) async {
+    final doc = await FirebaseFirestore.instance.collection('users').doc(uid).get();
+    if (doc.exists) {
+      final data = doc.data();
+      if (data != null && mounted) {
+        setState(() {
+          selectedGenres = List<String>.from(data['favoriteGenres'] ?? []);
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final authControllerState = ref.watch(authControllerProvider);
     final user = ref.watch(authStateChangesProvider).valueOrNull;
     final currentTheme = ref.watch(themeNotifierProvider);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Profile & Settings'),
-      ),
-      body: ListView(
-        padding: const EdgeInsets.all(16.0),
-        children: [
-          if (user != null)
-            Card(
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                  children: [
-                    CircleAvatar(
-                      radius: 40,
-                      backgroundColor: Theme.of(context).colorScheme.primaryContainer,
-                      child: Text(
-                        user.displayName?.isNotEmpty == true ? user.displayName!.substring(0, 1).toUpperCase() : (user.email?.substring(0, 1).toUpperCase() ?? 'U'),
-                        style: const TextStyle(fontSize: 40),
+      appBar: AppBar(title: const Text('Profile & Settings')),
+      body: Form(
+        key: _formKey,
+        child: ListView(
+          padding: const EdgeInsets.all(16.0),
+          children: [
+            if (user != null)
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Column(
+                    children: [
+                      CircleAvatar(
+                        radius: 40,
+                        backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+                        child: Text(
+                          user.displayName?.isNotEmpty == true
+                              ? user.displayName!.substring(0, 1).toUpperCase()
+                              : (user.email?.substring(0, 1).toUpperCase() ?? 'U'),
+                          style: const TextStyle(fontSize: 40),
+                        ),
                       ),
-                    ),
-                    const SizedBox(height: 16),
-                    Text(
-                      user.displayName ?? 'No display name',
-                      style: Theme.of(context).textTheme.headlineSmall,
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      user.email ?? 'No email',
-                      style: Theme.of(context).textTheme.bodyLarge,
-                    ),
-                  ],
+                      const SizedBox(height: 16),
+                      TextFormField(
+                        controller: _displayNameController,
+                        decoration: const InputDecoration(labelText: 'Display Name'),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(user.email ?? 'No email', style: Theme.of(context).textTheme.bodyLarge),
+                    ],
+                  ),
                 ),
               ),
+            const SizedBox(height: 24),
+            Text('Favorite Genres', style: Theme.of(context).textTheme.titleLarge),
+            const Divider(),
+            Wrap(
+              spacing: 8,
+              children: allGenres.map((genre) {
+                final selected = selectedGenres.contains(genre);
+                return FilterChip(
+                  label: Text(genre),
+                  selected: selected,
+                  onSelected: (bool value) {
+                    setState(() {
+                      if (value) {
+                        selectedGenres.add(genre);
+                      } else {
+                        selectedGenres.remove(genre);
+                      }
+                    });
+                  },
+                );
+              }).toList(),
             ),
-          const SizedBox(height: 24),
-          Text('Settings', style: Theme.of(context).textTheme.titleLarge),
-          const Divider(),
-          ListTile(
-            title: const Text('App Theme'),
-            subtitle: SegmentedButton<ThemeMode>(
-              segments: const [
-                ButtonSegment(value: ThemeMode.light, label: Text('Light'), icon: Icon(Icons.light_mode)),
-                ButtonSegment(value: ThemeMode.dark, label: Text('Dark'), icon: Icon(Icons.dark_mode)),
-                ButtonSegment(value: ThemeMode.system, label: Text('System'), icon: Icon(Icons.settings)),
-              ],
-              selected: {currentTheme},
-              onSelectionChanged: (newSelection) {
-                ref.read(themeNotifierProvider.notifier).setTheme(newSelection.first);
+            const SizedBox(height: 24),
+            Text('Settings', style: Theme.of(context).textTheme.titleLarge),
+            const Divider(),
+            ListTile(
+              title: const Text('App Theme'),
+              subtitle: SegmentedButton<ThemeMode>(
+                segments: const [
+                  ButtonSegment(value: ThemeMode.light, label: Text('Light'), icon: Icon(Icons.light_mode)),
+                  ButtonSegment(value: ThemeMode.dark, label: Text('Dark'), icon: Icon(Icons.dark_mode)),
+                  ButtonSegment(value: ThemeMode.system, label: Text('System'), icon: Icon(Icons.settings)),
+                ],
+                selected: {currentTheme},
+                onSelectionChanged: (newSelection) {
+                  ref.read(themeNotifierProvider.notifier).setTheme(newSelection.first);
+                },
+              ),
+            ),
+            ListTile(
+              leading: const Icon(Icons.help_outline),
+              title: const Text('Help & FAQ'),
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => const FAQScreen()),
+                );
               },
             ),
-          ),
-          const SizedBox(height: 24),
-          ElevatedButton.icon(
-            icon: const Icon(Icons.logout),
-            label: const Text('Sign Out'),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.error,
-              foregroundColor: Theme.of(context).colorScheme.onError,
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              icon: const Icon(Icons.save),
+              label: const Text('Save Changes'),
+              onPressed: () async {
+                final newName = _displayNameController.text.trim();
+                final uid = user?.uid;
+                if (uid != null && newName.isNotEmpty) {
+                  await user!.updateDisplayName(newName);
+                  await ref.read(userProfileRepositoryProvider).createUserProfile(
+                    uid: uid,
+                    email: user.email!,
+                    displayName: newName,
+                    favoriteGenres: selectedGenres,
+                  );
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Profile updated')),
+                    );
+                  }
+                }
+              },
             ),
-            onPressed: authControllerState.isLoading
-                ? null
-                : () {
-              ref.read(authControllerProvider.notifier).signOut();
-            },
-          ),
-        ],
+            const SizedBox(height: 12),
+            ElevatedButton.icon(
+              icon: const Icon(Icons.logout),
+              label: const Text('Sign Out'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Theme.of(context).colorScheme.error,
+                foregroundColor: Theme.of(context).colorScheme.onError,
+              ),
+              onPressed: authControllerState.isLoading
+                  ? null
+                  : () {
+                ref.read(authControllerProvider.notifier).signOut();
+              },
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,6 +12,7 @@ import firebase_auth
 import firebase_core
 import firebase_storage
 import path_provider_foundation
+import shared_preferences_foundation
 import syncfusion_pdfviewer_macos
 import url_launcher_macos
 
@@ -23,6 +24,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SyncfusionFlutterPdfViewerPlugin.register(with: registry.registrar(forPlugin: "SyncfusionFlutterPdfViewerPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -446,7 +446,7 @@ packages:
     source: sdk
     version: "0.0.0"
   freezed_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: freezed_annotation
       sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
@@ -622,7 +622,7 @@ packages:
     source: hosted
     version: "0.7.2"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
       sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
@@ -861,6 +861,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.3"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "20cbd561f743a342c76c151d6ddb93a9ce6005751e7aa458baad3858bfbfb6ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.10"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:


### PR DESCRIPTION
## ✨ Feature: Profile Update & FAQ Submission UI

### 🔧 Summary
This PR enhances the user profile screen and introduces a structured Help & FAQ section.

---

### ✅ Implemented
- **Editable Display Name**
  - Updates FirebaseAuth display name
  - Persists to Firestore `users` collection
- **Favorite Genres Selection**
  - Multi-select chip UI
  - Saved to Firestore
  - Genres are preloaded from Firestore on screen open
- **Theme Preference Toggle**
  - User can select light, dark, or system theme
- **FAQ Screen (Modularized)**
  - Separated into `faq_screen.dart`
  - Includes question input and submit button (currently a placeholder snackbar)

---

### 📁 File Changes
- `profile_screen.dart`: Added editing, genre sync, FAQ navigation
- `faq_screen.dart`: New screen with input + submit

---

### 🧪 How to Test
1. Go to **Profile & Settings**
2. Change name and genres → Save → verify in Firestore
3. Tap **Help & FAQ** → type a message → Submit → snackbar should confirm

---

### ⏭️ Next Steps
- Connect FAQ submissions to Firestore or support API
- Optionally add profile picture editing
